### PR TITLE
Fix shlex dependency

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -30,7 +30,7 @@
          }
        ],
       "dependencies": {
-         "shlex": ">=0.9.5"
+         "shlex:library": ">=0.9.5"
       }
      },
      {


### PR DESCRIPTION
The way it's written now causes distro-dlang to depend on shlex's test subpackage, which in turn causes distro-dlang to link with two versions of libshlex.a. The only reason that's not usually a problem with dub is that the linker throws away code that's not used and duplicate code in static libraries. It still means extra build time though.